### PR TITLE
fix: add URL path escaping to client resource paths

### DIFF
--- a/internal/client/acls.go
+++ b/internal/client/acls.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"net/url"
 )
 
 // ACLObjectType represents the type of object an ACL applies to
@@ -90,7 +91,7 @@ func (c *Client) CreateACL(ctx context.Context, req *CreateACLRequest) (*ACL, er
 // GetACL retrieves an ACL by ID
 func (c *Client) GetACL(ctx context.Context, id string) (*ACL, error) {
 	var acl ACL
-	err := c.Do(ctx, "GET", fmt.Sprintf("/v1/acl/%s", id), nil, &acl)
+	err := c.Do(ctx, "GET", "/v1/acl/"+url.PathEscape(id), nil, &acl)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +100,7 @@ func (c *Client) GetACL(ctx context.Context, id string) (*ACL, error) {
 
 // DeleteACL deletes an ACL
 func (c *Client) DeleteACL(ctx context.Context, id string) error {
-	return c.Do(ctx, "DELETE", fmt.Sprintf("/v1/acl/%s", id), nil, nil)
+	return c.Do(ctx, "DELETE", "/v1/acl/"+url.PathEscape(id), nil, nil)
 }
 
 // ListACLs lists all ACLs for a given object

--- a/internal/client/api_keys.go
+++ b/internal/client/api_keys.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"net/url"
 )
 
 // APIKey represents a Braintrust API key
@@ -55,7 +56,7 @@ func (c *Client) CreateAPIKey(ctx context.Context, req *CreateAPIKeyRequest) (*A
 // GetAPIKey retrieves an API key by ID
 func (c *Client) GetAPIKey(ctx context.Context, id string) (*APIKey, error) {
 	var apiKey APIKey
-	err := c.Do(ctx, "GET", fmt.Sprintf("/v1/api_key/%s", id), nil, &apiKey)
+	err := c.Do(ctx, "GET", "/v1/api_key/"+url.PathEscape(id), nil, &apiKey)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +66,7 @@ func (c *Client) GetAPIKey(ctx context.Context, id string) (*APIKey, error) {
 // UpdateAPIKey updates an existing API key
 func (c *Client) UpdateAPIKey(ctx context.Context, id string, req *UpdateAPIKeyRequest) (*APIKey, error) {
 	var apiKey APIKey
-	err := c.Do(ctx, "PATCH", fmt.Sprintf("/v1/api_key/%s", id), req, &apiKey)
+	err := c.Do(ctx, "PATCH", "/v1/api_key/"+url.PathEscape(id), req, &apiKey)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +75,7 @@ func (c *Client) UpdateAPIKey(ctx context.Context, id string, req *UpdateAPIKeyR
 
 // DeleteAPIKey deletes an API key
 func (c *Client) DeleteAPIKey(ctx context.Context, id string) error {
-	return c.Do(ctx, "DELETE", fmt.Sprintf("/v1/api_key/%s", id), nil, nil)
+	return c.Do(ctx, "DELETE", "/v1/api_key/"+url.PathEscape(id), nil, nil)
 }
 
 // ListAPIKeys lists all API keys

--- a/internal/client/groups.go
+++ b/internal/client/groups.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"net/url"
 )
 
 // Group represents a Braintrust group
@@ -60,7 +61,7 @@ func (c *Client) CreateGroup(ctx context.Context, req *CreateGroupRequest) (*Gro
 // GetGroup retrieves a group by ID
 func (c *Client) GetGroup(ctx context.Context, id string) (*Group, error) {
 	var group Group
-	err := c.Do(ctx, "GET", fmt.Sprintf("/v1/group/%s", id), nil, &group)
+	err := c.Do(ctx, "GET", "/v1/group/"+url.PathEscape(id), nil, &group)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +71,7 @@ func (c *Client) GetGroup(ctx context.Context, id string) (*Group, error) {
 // UpdateGroup updates an existing group
 func (c *Client) UpdateGroup(ctx context.Context, id string, req *UpdateGroupRequest) (*Group, error) {
 	var group Group
-	err := c.Do(ctx, "PATCH", fmt.Sprintf("/v1/group/%s", id), req, &group)
+	err := c.Do(ctx, "PATCH", "/v1/group/"+url.PathEscape(id), req, &group)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +80,7 @@ func (c *Client) UpdateGroup(ctx context.Context, id string, req *UpdateGroupReq
 
 // DeleteGroup deletes a group
 func (c *Client) DeleteGroup(ctx context.Context, id string) error {
-	return c.Do(ctx, "DELETE", fmt.Sprintf("/v1/group/%s", id), nil, nil)
+	return c.Do(ctx, "DELETE", "/v1/group/"+url.PathEscape(id), nil, nil)
 }
 
 // ListGroups lists all groups for an organization

--- a/internal/client/projects.go
+++ b/internal/client/projects.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"net/url"
 )
 
 // Project represents a Braintrust project
@@ -59,7 +60,7 @@ func (c *Client) CreateProject(ctx context.Context, req *CreateProjectRequest) (
 // GetProject retrieves a project by ID
 func (c *Client) GetProject(ctx context.Context, id string) (*Project, error) {
 	var project Project
-	err := c.Do(ctx, "GET", fmt.Sprintf("/v1/project/%s", id), nil, &project)
+	err := c.Do(ctx, "GET", "/v1/project/"+url.PathEscape(id), nil, &project)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +70,7 @@ func (c *Client) GetProject(ctx context.Context, id string) (*Project, error) {
 // UpdateProject updates an existing project
 func (c *Client) UpdateProject(ctx context.Context, id string, req *UpdateProjectRequest) (*Project, error) {
 	var project Project
-	err := c.Do(ctx, "PATCH", fmt.Sprintf("/v1/project/%s", id), req, &project)
+	err := c.Do(ctx, "PATCH", "/v1/project/"+url.PathEscape(id), req, &project)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +79,7 @@ func (c *Client) UpdateProject(ctx context.Context, id string, req *UpdateProjec
 
 // DeleteProject deletes a project (soft delete)
 func (c *Client) DeleteProject(ctx context.Context, id string) error {
-	return c.Do(ctx, "DELETE", fmt.Sprintf("/v1/project/%s", id), nil, nil)
+	return c.Do(ctx, "DELETE", "/v1/project/"+url.PathEscape(id), nil, nil)
 }
 
 // ListProjects lists all projects

--- a/internal/client/roles.go
+++ b/internal/client/roles.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"net/url"
 )
 
 // Role represents a Braintrust role
@@ -64,7 +65,7 @@ func (c *Client) CreateRole(ctx context.Context, req *CreateRoleRequest) (*Role,
 // GetRole retrieves a role by ID
 func (c *Client) GetRole(ctx context.Context, id string) (*Role, error) {
 	var role Role
-	err := c.Do(ctx, "GET", fmt.Sprintf("/v1/role/%s", id), nil, &role)
+	err := c.Do(ctx, "GET", "/v1/role/"+url.PathEscape(id), nil, &role)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +75,7 @@ func (c *Client) GetRole(ctx context.Context, id string) (*Role, error) {
 // UpdateRole updates an existing role
 func (c *Client) UpdateRole(ctx context.Context, id string, req *UpdateRoleRequest) (*Role, error) {
 	var role Role
-	err := c.Do(ctx, "PATCH", fmt.Sprintf("/v1/role/%s", id), req, &role)
+	err := c.Do(ctx, "PATCH", "/v1/role/"+url.PathEscape(id), req, &role)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +84,7 @@ func (c *Client) UpdateRole(ctx context.Context, id string, req *UpdateRoleReque
 
 // DeleteRole deletes a role (soft delete)
 func (c *Client) DeleteRole(ctx context.Context, id string) error {
-	return c.Do(ctx, "DELETE", fmt.Sprintf("/v1/role/%s", id), nil, nil)
+	return c.Do(ctx, "DELETE", "/v1/role/"+url.PathEscape(id), nil, nil)
 }
 
 // ListRoles lists all roles


### PR DESCRIPTION
## Problem

Fixes #32

Client files for projects, groups, roles, api_keys, and acls were not escaping special characters in resource IDs when constructing URL paths. This could lead to malformed URLs when IDs contain spaces, slashes, or Unicode characters.

## Changes

Updated 5 client files to use `url.PathEscape()` for resource IDs in URL paths:

1. **internal/client/projects.go** - GetProject, UpdateProject, DeleteProject
2. **internal/client/groups.go** - GetGroup, UpdateGroup, DeleteGroup  
3. **internal/client/roles.go** - GetRole, UpdateRole, DeleteRole
4. **internal/client/api_keys.go** - GetAPIKey, UpdateAPIKey, DeleteAPIKey
5. **internal/client/acls.go** - GetACL, DeleteACL

### Pattern Applied

**Before:**
```go
fmt.Sprintf("/v1/resource/%s", id)
```

**After:**
```go
"/v1/resource/" + url.PathEscape(id)
```

This matches the pattern used in `experiments.go` (the reference implementation).

## Verification

✅ All tests pass (`make test`) - 92 tests, 83.2% coverage
✅ Linting passes (`make lint`) - 0 issues
✅ PAL precommit validation passed

## Security Impact

This fix prevents potential security issues and API call failures when resource IDs contain special characters.