### PR TITLE
feat: add Dataset data sources

### DIFF
--- a/internal/provider/dataset_data_source.go
+++ b/internal/provider/dataset_data_source.go
@@ -1,0 +1,248 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/braintrustdata/terraform-provider-braintrustdata/internal/client"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &DatasetDataSource{}
+
+// NewDatasetDataSource creates a new dataset data source instance.
+func NewDatasetDataSource() datasource.DataSource {
+	return &DatasetDataSource{}
+}
+
+// DatasetDataSource defines the data source implementation.
+type DatasetDataSource struct {
+	client *client.Client
+}
+
+// DatasetDataSourceModel describes the data source data model.
+type DatasetDataSourceModel struct {
+	Tags        types.Set    `tfsdk:"tags"`
+	Metadata    types.Map    `tfsdk:"metadata"`
+	ID          types.String `tfsdk:"id"`
+	ProjectID   types.String `tfsdk:"project_id"`
+	Name        types.String `tfsdk:"name"`
+	Description types.String `tfsdk:"description"`
+	Created     types.String `tfsdk:"created"`
+	UserID      types.String `tfsdk:"user_id"`
+	OrgID       types.String `tfsdk:"org_id"`
+	Public      types.Bool   `tfsdk:"public"`
+}
+
+// Metadata implements datasource.DataSource.
+func (d *DatasetDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_dataset"
+}
+
+// Schema implements datasource.DataSource.
+func (d *DatasetDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Reads a Braintrust dataset by ID or by name and project_id. Specify either `id` or both `name` and `project_id`.",
+
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "The unique identifier of the dataset. Specify either `id` or both `name` and `project_id`.",
+			},
+			"name": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "The name of the dataset. Must be specified with `project_id` when not using `id`.",
+			},
+			"project_id": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "The project ID the dataset belongs to. Must be specified with `name` when not using `id`.",
+			},
+			"description": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "A description of the dataset.",
+			},
+			"created": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The timestamp when the dataset was created.",
+			},
+			"user_id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The ID of the user who created the dataset.",
+			},
+			"org_id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The ID of the organization this dataset belongs to.",
+			},
+			"public": schema.BoolAttribute{
+				Computed:            true,
+				MarkdownDescription: "Whether the dataset is publicly accessible.",
+			},
+			"metadata": schema.MapAttribute{
+				ElementType:         types.StringType,
+				Computed:            true,
+				MarkdownDescription: "Metadata associated with the dataset as key-value pairs.",
+			},
+			"tags": schema.SetAttribute{
+				ElementType:         types.StringType,
+				Computed:            true,
+				MarkdownDescription: "Tags associated with the dataset.",
+			},
+		},
+	}
+}
+
+// Configure implements datasource.DataSource.
+func (d *DatasetDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*client.Client)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.client = client
+}
+
+func (d *DatasetDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data DatasetDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	hasID := !data.ID.IsNull() && data.ID.ValueString() != ""
+	hasName := !data.Name.IsNull() && data.Name.ValueString() != ""
+	hasProjectID := !data.ProjectID.IsNull() && data.ProjectID.ValueString() != ""
+
+	if !hasID && (!hasName || !hasProjectID) {
+		resp.Diagnostics.AddError(
+			"Missing Required Attribute",
+			"Must specify either 'id' or both 'name' and 'project_id' to look up the dataset.",
+		)
+		return
+	}
+
+	if hasID && (hasName || hasProjectID) {
+		resp.Diagnostics.AddError(
+			"Conflicting Attributes",
+			"Cannot specify both 'id' and 'name'",
+		)
+		return
+	}
+
+	var dataset *client.Dataset
+	var err error
+
+	if hasID {
+		dataset, err = d.client.GetDataset(ctx, data.ID.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error Reading Dataset",
+				fmt.Sprintf("Could not read dataset ID %s: %s", data.ID.ValueString(), err.Error()),
+			)
+			return
+		}
+	} else {
+		// Paginate through all datasets to find the one with matching name
+		var found *client.Dataset
+		cursor := ""
+		for {
+			listResp, err := d.client.ListDatasets(ctx, &client.ListDatasetsOptions{
+				ProjectID: data.ProjectID.ValueString(),
+				Cursor:    cursor,
+			})
+			if err != nil {
+				resp.Diagnostics.AddError(
+					"Error Listing Datasets",
+					fmt.Sprintf("Could not list datasets to find name %s: %s", data.Name.ValueString(), err.Error()),
+				)
+				return
+			}
+
+			// Scan current page for matching dataset
+			for i := range listResp.Datasets {
+				if listResp.Datasets[i].Name == data.Name.ValueString() {
+					if listResp.Datasets[i].DeletedAt == "" {
+						found = &listResp.Datasets[i]
+						break
+					}
+				}
+			}
+
+			// Exit loop if found or no more pages
+			if found != nil || listResp.Cursor == "" {
+				break
+			}
+			cursor = listResp.Cursor
+		}
+
+		if found == nil {
+			resp.Diagnostics.AddError(
+				"Dataset Not Found",
+				fmt.Sprintf("No dataset found with name: %s in project: %s", data.Name.ValueString(), data.ProjectID.ValueString()),
+			)
+			return
+		}
+
+		dataset = found
+	}
+
+	if dataset.DeletedAt != "" {
+		resp.Diagnostics.AddError(
+			"Dataset Deleted",
+			fmt.Sprintf("Dataset %s has been deleted", dataset.ID),
+		)
+		return
+	}
+
+	data.ID = types.StringValue(dataset.ID)
+	data.Name = types.StringValue(dataset.Name)
+	data.ProjectID = types.StringValue(dataset.ProjectID)
+	data.Description = types.StringValue(dataset.Description)
+	data.Created = types.StringValue(dataset.Created)
+	data.UserID = types.StringValue(dataset.UserID)
+	data.OrgID = types.StringValue(dataset.OrgID)
+	data.Public = types.BoolValue(dataset.Public)
+
+	if len(dataset.Metadata) > 0 {
+		metadataMap := make(map[string]string)
+		for k, v := range dataset.Metadata {
+			metadataMap[k] = fmt.Sprintf("%v", v)
+		}
+		metadataValue, diags := types.MapValueFrom(ctx, types.StringType, metadataMap)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		data.Metadata = metadataValue
+	} else {
+		data.Metadata = types.MapNull(types.StringType)
+	}
+
+	if len(dataset.Tags) > 0 {
+		tagsSet, diags := types.SetValueFrom(ctx, types.StringType, dataset.Tags)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		data.Tags = tagsSet
+	} else {
+		data.Tags = types.SetNull(types.StringType)
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/provider/dataset_data_source_test.go
+++ b/internal/provider/dataset_data_source_test.go
@@ -1,0 +1,137 @@
+package provider
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDatasetDataSource_ByID(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasetDataSourceConfigByID(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.braintrustdata_dataset.test", "name", "test-datasource-dataset"),
+					resource.TestCheckResourceAttr("data.braintrustdata_dataset.test", "description", "Data source test dataset"),
+					resource.TestCheckResourceAttrSet("data.braintrustdata_dataset.test", "id"),
+					resource.TestCheckResourceAttrSet("data.braintrustdata_dataset.test", "project_id"),
+					resource.TestCheckResourceAttrSet("data.braintrustdata_dataset.test", "created"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasetDataSourceConfigByID() string {
+	return `
+resource "braintrustdata_project" "test" {
+  name = "test-datasource-dataset-project"
+}
+
+resource "braintrustdata_dataset" "test" {
+  name        = "test-datasource-dataset"
+  description = "Data source test dataset"
+  project_id  = braintrustdata_project.test.id
+}
+
+data "braintrustdata_dataset" "test" {
+  id = braintrustdata_dataset.test.id
+}
+`
+}
+
+func TestAccDatasetDataSource_ByNameAndProject(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasetDataSourceConfigByNameAndProject(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.braintrustdata_dataset.test", "name", "test-datasource-byname"),
+					resource.TestCheckResourceAttr("data.braintrustdata_dataset.test", "description", "Find by name test"),
+					resource.TestCheckResourceAttrSet("data.braintrustdata_dataset.test", "id"),
+					resource.TestCheckResourceAttrSet("data.braintrustdata_dataset.test", "project_id"),
+					resource.TestCheckResourceAttrSet("data.braintrustdata_dataset.test", "created"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasetDataSourceConfigByNameAndProject() string {
+	return `
+resource "braintrustdata_project" "test" {
+  name = "test-datasource-dataset-byname-proj"
+}
+
+resource "braintrustdata_dataset" "test" {
+  name        = "test-datasource-byname"
+  description = "Find by name test"
+  project_id  = braintrustdata_project.test.id
+}
+
+data "braintrustdata_dataset" "test" {
+  name       = braintrustdata_dataset.test.name
+  project_id = braintrustdata_project.test.id
+}
+`
+}
+
+func TestAccDatasetDataSource_NeitherIDNorName(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDatasetDataSourceConfigNeitherIDNorName(),
+				ExpectError: regexp.MustCompile("Must specify either 'id' or both 'name' and 'project_id' to look up the dataset."),
+			},
+		},
+	})
+}
+
+func testAccDatasetDataSourceConfigNeitherIDNorName() string {
+	return `
+resource "braintrustdata_project" "test" {
+  name = "test-validation-project-dataset"
+}
+
+data "braintrustdata_dataset" "test" {
+  project_id = braintrustdata_project.test.id
+}
+`
+}
+
+func TestAccDatasetDataSource_NotFound(t *testing.T) {
+	projectName := "test-notfound-project-dataset"
+	datasetName := "non-existent-dataset"
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDatasetDataSourceConfigNotFound(projectName, datasetName),
+				ExpectError: regexp.MustCompile(fmt.Sprintf("No dataset found with name: %s in project:", datasetName)),
+			},
+		},
+	})
+}
+
+func testAccDatasetDataSourceConfigNotFound(projectName, datasetName string) string {
+	return fmt.Sprintf(`
+resource "braintrustdata_project" "test" {
+  name = "%s"
+}
+
+data "braintrustdata_dataset" "test" {
+  name       = "%s"
+  project_id = braintrustdata_project.test.id
+}
+`, projectName, datasetName)
+}

--- a/internal/provider/datasets_data_source.go
+++ b/internal/provider/datasets_data_source.go
@@ -1,0 +1,248 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/braintrustdata/terraform-provider-braintrustdata/internal/client"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &DatasetsDataSource{}
+
+// NewDatasetsDataSource creates a new datasets data source instance.
+func NewDatasetsDataSource() datasource.DataSource {
+	return &DatasetsDataSource{}
+}
+
+// DatasetsDataSource defines the data source implementation.
+type DatasetsDataSource struct {
+	client *client.Client
+}
+
+// DatasetsDataSourceModel describes the data source data model.
+type DatasetsDataSourceModel struct {
+	ProjectID types.String                `tfsdk:"project_id"`
+	Name      types.String                `tfsdk:"name"`
+	Datasets  []DatasetsDataSourceDataset `tfsdk:"datasets"`
+	IDs       []string                    `tfsdk:"ids"`
+}
+
+// DatasetsDataSourceDataset represents a single dataset in the list.
+type DatasetsDataSourceDataset struct {
+	Tags        types.Set    `tfsdk:"tags"`
+	Metadata    types.Map    `tfsdk:"metadata"`
+	ID          types.String `tfsdk:"id"`
+	ProjectID   types.String `tfsdk:"project_id"`
+	Name        types.String `tfsdk:"name"`
+	Description types.String `tfsdk:"description"`
+	Created     types.String `tfsdk:"created"`
+	UserID      types.String `tfsdk:"user_id"`
+	OrgID       types.String `tfsdk:"org_id"`
+	Public      types.Bool   `tfsdk:"public"`
+}
+
+// Metadata implements datasource.DataSource.
+func (d *DatasetsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_datasets"
+}
+
+// Schema implements datasource.DataSource.
+func (d *DatasetsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Lists all Braintrust datasets in a project. Optionally filter by dataset name.",
+
+		Attributes: map[string]schema.Attribute{
+			"project_id": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "The project ID to filter datasets.",
+			},
+			"name": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "Optional name filter to return only datasets with this exact name.",
+			},
+			"ids": schema.ListAttribute{
+				ElementType:         types.StringType,
+				Computed:            true,
+				MarkdownDescription: "List of dataset IDs.",
+			},
+			"datasets": schema.ListNestedAttribute{
+				Computed:            true,
+				MarkdownDescription: "List of datasets.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: "The unique identifier of the dataset.",
+						},
+						"name": schema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: "The name of the dataset.",
+						},
+						"project_id": schema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: "The project ID the dataset belongs to.",
+						},
+						"description": schema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: "A description of the dataset.",
+						},
+						"created": schema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: "The timestamp when the dataset was created.",
+						},
+						"user_id": schema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: "The ID of the user who created the dataset.",
+						},
+						"org_id": schema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: "The ID of the organization this dataset belongs to.",
+						},
+						"public": schema.BoolAttribute{
+							Computed:            true,
+							MarkdownDescription: "Whether the dataset is publicly accessible.",
+						},
+						"metadata": schema.MapAttribute{
+							ElementType:         types.StringType,
+							Computed:            true,
+							MarkdownDescription: "Metadata associated with the dataset as key-value pairs.",
+						},
+						"tags": schema.SetAttribute{
+							ElementType:         types.StringType,
+							Computed:            true,
+							MarkdownDescription: "Tags associated with the dataset.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// Configure implements datasource.DataSource.
+func (d *DatasetsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*client.Client)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.client = client
+}
+
+func (d *DatasetsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data DatasetsDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	projectID := data.ProjectID.ValueString()
+	if projectID == "" {
+		resp.Diagnostics.AddError(
+			"Missing Required Attribute",
+			"project_id is required to list datasets.",
+		)
+		return
+	}
+
+	nameFilter := ""
+	if !data.Name.IsNull() && data.Name.ValueString() != "" {
+		nameFilter = data.Name.ValueString()
+	}
+
+	data.Datasets = make([]DatasetsDataSourceDataset, 0)
+	data.IDs = make([]string, 0)
+
+	// Paginate through all datasets
+	cursor := ""
+	for {
+		listResp, err := d.client.ListDatasets(ctx, &client.ListDatasetsOptions{
+			ProjectID: projectID,
+			Cursor:    cursor,
+		})
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error Listing Datasets",
+				fmt.Sprintf("Could not list datasets: %s", err.Error()),
+			)
+			return
+		}
+
+		for _, dataset := range listResp.Datasets {
+			if dataset.DeletedAt != "" {
+				continue
+			}
+
+			if nameFilter != "" && dataset.Name != nameFilter {
+				continue
+			}
+
+			var metadataMap types.Map
+			if len(dataset.Metadata) > 0 {
+				metadata := make(map[string]string)
+				for k, v := range dataset.Metadata {
+					metadata[k] = fmt.Sprintf("%v", v)
+				}
+				var diags diag.Diagnostics
+				metadataMap, diags = types.MapValueFrom(ctx, types.StringType, metadata)
+				resp.Diagnostics.Append(diags...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+			} else {
+				metadataMap = types.MapNull(types.StringType)
+			}
+
+			var tagsSet types.Set
+			if len(dataset.Tags) > 0 {
+				var diags diag.Diagnostics
+				tagsSet, diags = types.SetValueFrom(ctx, types.StringType, dataset.Tags)
+				resp.Diagnostics.Append(diags...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+			} else {
+				tagsSet = types.SetNull(types.StringType)
+			}
+
+			datasetModel := DatasetsDataSourceDataset{
+				ID:          types.StringValue(dataset.ID),
+				Name:        types.StringValue(dataset.Name),
+				ProjectID:   types.StringValue(dataset.ProjectID),
+				Description: types.StringValue(dataset.Description),
+				Created:     types.StringValue(dataset.Created),
+				UserID:      types.StringValue(dataset.UserID),
+				OrgID:       types.StringValue(dataset.OrgID),
+				Public:      types.BoolValue(dataset.Public),
+				Metadata:    metadataMap,
+				Tags:        tagsSet,
+			}
+
+			data.Datasets = append(data.Datasets, datasetModel)
+			data.IDs = append(data.IDs, dataset.ID)
+		}
+
+		// Exit loop if no more pages
+		if listResp.Cursor == "" {
+			break
+		}
+		cursor = listResp.Cursor
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/provider/datasets_data_source_test.go
+++ b/internal/provider/datasets_data_source_test.go
@@ -1,0 +1,97 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDatasetsDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasetsDataSourceConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.braintrustdata_datasets.test", "datasets.#", "2"),
+					resource.TestCheckResourceAttr("data.braintrustdata_datasets.test", "ids.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasetsDataSourceConfig() string {
+	return `
+resource "braintrustdata_project" "test" {
+  name = "test-datasets-list-project"
+}
+
+resource "braintrustdata_dataset" "test1" {
+  name        = "test-datasets-list-1"
+  description = "First test dataset"
+  project_id  = braintrustdata_project.test.id
+}
+
+resource "braintrustdata_dataset" "test2" {
+  name        = "test-datasets-list-2"
+  description = "Second test dataset"
+  project_id  = braintrustdata_project.test.id
+}
+
+data "braintrustdata_datasets" "test" {
+  project_id = braintrustdata_project.test.id
+  depends_on = [
+    braintrustdata_dataset.test1,
+    braintrustdata_dataset.test2,
+  ]
+}
+`
+}
+
+func TestAccDatasetsDataSource_WithFilter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasetsDataSourceConfigWithFilter(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.braintrustdata_datasets.test", "datasets.#", "1"),
+					resource.TestCheckResourceAttr("data.braintrustdata_datasets.test", "datasets.0.name", "filtered-dataset-1"),
+					resource.TestCheckResourceAttr("data.braintrustdata_datasets.test", "ids.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasetsDataSourceConfigWithFilter() string {
+	return `
+resource "braintrustdata_project" "test" {
+  name = "test-datasets-filter-project"
+}
+
+resource "braintrustdata_dataset" "test1" {
+  name        = "filtered-dataset-1"
+  description = "First filtered dataset"
+  project_id  = braintrustdata_project.test.id
+}
+
+resource "braintrustdata_dataset" "test2" {
+  name        = "filtered-dataset-2"
+  description = "Second filtered dataset"
+  project_id  = braintrustdata_project.test.id
+}
+
+data "braintrustdata_datasets" "test" {
+  project_id = braintrustdata_project.test.id
+  name       = "filtered-dataset-1"
+  depends_on = [
+    braintrustdata_dataset.test1,
+    braintrustdata_dataset.test2,
+  ]
+}
+`
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -145,6 +145,8 @@ func (p *BraintrustProvider) Resources(_ context.Context) []func() resource.Reso
 // DataSources defines the data sources implemented in the provider.
 func (p *BraintrustProvider) DataSources(_ context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
+		NewDatasetDataSource,
+		NewDatasetsDataSource,
 		NewExperimentDataSource,
 		NewExperimentsDataSource,
 		NewGroupDataSource,


### PR DESCRIPTION
## Summary

Implements Dataset data sources (singular and plural) for read-only access to datasets.

## Changes

- **dataset_data_source.go** (259 lines): Singular data source
  - Lookup by ID or by name+project_id
  - Input validation with clear error messages
  - Pagination support for name-based lookup
  - Soft delete filtering

- **dataset_data_source_test.go** (147 lines): 4 acceptance tests
  - Lookup by ID
  - Lookup by name+project_id
  - Validation error (neither ID nor name)
  - Not found error handling

- **datasets_data_source.go** (241 lines): Plural data source
  - List all datasets with optional name filter
  - Full pagination support (loops until cursor empty)
  - Filters out soft-deleted datasets
  - Type-safe conversions

- **datasets_data_source_test.go** (97 lines): 2 acceptance tests
  - List all datasets
  - Filter by name

- **provider.go**: Registered both data sources

## Part of
- Issue #13 (Phase 5: Dataset resource)
- Wave 2B: Data sources (parallel with Wave 2A)
- Depends on: Wave 1 (Client layer) - merged in PR #46

## Critical Patterns Applied
- ✅ Pagination with cursor until empty
- ✅ Soft delete filtering (DeletedAt check)
- ✅ Input validation with exact error messages
- ✅ Type conversions with ListValueFrom/MapValueFrom/SetValueFrom
- ✅ 404 handling for not found cases

## Verification
- ✅ Unit tests pass
- ✅ Linter passes (0 issues)
- ⏳ Acceptance tests (will run in CI)