### PR TITLE
fix: restore env vars in TestProviderConfigure_ValidationRequired

### DIFF
--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -95,9 +95,23 @@ func TestProviderConfigure_DefaultAPIURL(t *testing.T) {
 
 // TestProviderConfigure_ValidationRequired verifies API key is required
 func TestProviderConfigure_ValidationRequired(t *testing.T) {
+	// Save original values
+	origAPIKey := os.Getenv("BRAINTRUST_API_KEY")
+	origOrgID := os.Getenv("BRAINTRUST_ORG_ID")
+
 	// Clear environment variables to test validation
 	_ = os.Unsetenv("BRAINTRUST_API_KEY")
 	_ = os.Unsetenv("BRAINTRUST_ORG_ID")
+
+	// Restore after test
+	defer func() {
+		if origAPIKey != "" {
+			_ = os.Setenv("BRAINTRUST_API_KEY", origAPIKey)
+		}
+		if origOrgID != "" {
+			_ = os.Setenv("BRAINTRUST_ORG_ID", origOrgID)
+		}
+	}()
 
 	// Validation will be tested via acceptance tests
 	// This test documents the requirement

--- a/internal/provider/role_resource_test.go
+++ b/internal/provider/role_resource_test.go
@@ -8,10 +8,6 @@ import (
 )
 
 func TestAccRoleResource(t *testing.T) {
-	t.Skip("TODO: This test fails in CI with 'Missing API Key Configuration' error during planning, " +
-		"despite API key being set in environment. The error occurs after other tests pass successfully. " +
-		"Needs investigation into test isolation or CI environment configuration.")
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,


### PR DESCRIPTION
## Summary
- Fixes test isolation bug in `TestProviderConfigure_ValidationRequired` that caused subsequent tests to fail
- Added defer cleanup to restore `BRAINTRUST_API_KEY` and `BRAINTRUST_ORG_ID` after test completes
- Removed skip from `TestAccRoleResource` now that isolation bug is fixed

## Changes
- **internal/provider/provider_test.go**: Added env var restoration in defer block
- **internal/provider/role_resource_test.go**: Removed `t.Skip()` call

## Verification
- ✅ All unit tests pass: `make test`
- ✅ All linters pass: `make lint`
- ✅ Role resource test no longer skipped

Fixes #26