### PR TITLE
fix(ci): quarantine flaky acceptance tests in CI only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,4 +122,5 @@ jobs:
           TF_ACC: "1"
           BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
           BRAINTRUST_ORG_ID: ${{ secrets.BRAINTRUST_ORG_ID }}
-        run: make testacc
+        # TODO(#65): remove CI quarantine after flaky acceptance tests are fixed.
+        run: go test ./internal/provider/... -v -count=1 -run '^TestAcc' -skip 'TestAccACLResource_WithRole|TestAccRoleResource' -timeout=120m


### PR DESCRIPTION
## What changed
- Updated `.github/workflows/test.yml` to quarantine flaky acceptance coverage in CI only.
- Added/updated `internal/provider/makefile_test.go` assertions to lock workflow behavior.

## Why
- CI acceptance runs are currently flaky due to backend behavior tracked in #65.
- This change isolates/quarantines the flaky path in CI to reduce false negatives while keeping local flows intact.

## Validation
- `make test`
- `make lint`

## Notes
- This is a CI-only quarantine.
- TODO(#65): remove quarantine once backend flakiness is fixed.

Refs #67
