### PR TITLE
fix(client): remediate baseline gosec findings

### DIFF
--- a/internal/client/api_keys.go
+++ b/internal/client/api_keys.go
@@ -47,6 +47,10 @@ type ListAPIKeysResponse struct {
 	APIKeys []APIKey `json:"objects"`
 }
 
+func apiKeyPath(id string) string {
+	return "/v1/api_key/" + url.PathEscape(id)
+}
+
 // CreateAPIKey creates a new API key
 func (c *Client) CreateAPIKey(ctx context.Context, req *CreateAPIKeyRequest) (*APIKey, error) {
 	var apiKey APIKey
@@ -63,7 +67,7 @@ func (c *Client) GetAPIKey(ctx context.Context, id string) (*APIKey, error) {
 		return nil, ErrEmptyAPIKeyID
 	}
 	var apiKey APIKey
-	err := c.Do(ctx, "GET", "/v1/api_key/"+url.PathEscape(id), nil, &apiKey)
+	err := c.Do(ctx, "GET", apiKeyPath(id), nil, &apiKey)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +80,7 @@ func (c *Client) UpdateAPIKey(ctx context.Context, id string, req *UpdateAPIKeyR
 		return nil, ErrEmptyAPIKeyID
 	}
 	var apiKey APIKey
-	err := c.Do(ctx, "PATCH", "/v1/api_key/"+url.PathEscape(id), req, &apiKey)
+	err := c.Do(ctx, "PATCH", apiKeyPath(id), req, &apiKey)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +92,7 @@ func (c *Client) DeleteAPIKey(ctx context.Context, id string) error {
 	if id == "" {
 		return ErrEmptyAPIKeyID
 	}
-	return c.Do(ctx, "DELETE", "/v1/api_key/"+url.PathEscape(id), nil, nil)
+	return c.Do(ctx, "DELETE", apiKeyPath(id), nil, nil)
 }
 
 // ListAPIKeys lists all API keys


### PR DESCRIPTION
## Summary
- remediate baseline `gosec` findings in `internal/client` with minimal behavioral scope
- harden URL handling in `Client.Do` with controlled validation (no panics)
- normalize query-only relative paths (e.g. `?a=b`) to `/` while preserving strict path safety checks
- centralize API key path construction and enforce escaped path-segment semantics
- update client tests to assert security behavior and escaped-path correctness

## Security rationale
- remove panic-based validation to avoid process crashes from config/user input
- enforce strict base URL validation: HTTPS-only, non-empty host, reject userinfo
- reject unsafe request forms: absolute URLs, non-rooted paths, dot-segment traversal, URL fragments
- preserve intended query support for relative API calls

## Validation evidence
Executed in worktree `/Users/boats/src/braintrust/terraform-provider-braintrustdata/.worktrees/issue-baseline-gosec`:
- `make fmt` ✅
- `make test` ✅
- `make lint` ✅ (`0 issues`)

Refs #73
