### PR TITLE
test: fix user data source missing-lookup acceptance assertion

### DIFF
--- a/internal/provider/user_data_source_test.go
+++ b/internal/provider/user_data_source_test.go
@@ -43,7 +43,7 @@ func TestAccUserDataSource_MissingLookupAttributes(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccUserDataSourceConfigMissingLookupAttributes(),
-				ExpectError: regexp.MustCompile(`Must specify either 'id' or at least one searchable attribute \('email', 'given_name', 'family_name'\)`),
+				ExpectError: regexp.MustCompile(`Must specify either 'id' or at least one searchable attribute`),
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

Fix-forward for post-merge acceptance failure in `TestAccUserDataSource_MissingLookupAttributes`.

- update `ExpectError` regex to assert the stable semantic prefix only
- avoid brittle matching on Terraform line wrapping / formatting
- keep scope limited to the failing acceptance test assertion

Fixes #89

## Validation

- `make fmt`
- `make test`
- `make lint`
- `source .envrc && TF_ACC=1 go test ./internal/provider -run 'TestAccUserDataSource|TestAccUsersDataSource' -count=1 -v`
