### PR TITLE
chore(ci): capture acceptance test logs on failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,4 +123,18 @@ jobs:
           BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
           BRAINTRUST_ORG_ID: ${{ secrets.BRAINTRUST_ORG_ID }}
         # TODO(#65): remove CI quarantine after flaky acceptance tests are fixed.
-        run: go test ./internal/provider/... -v -count=1 -run '^TestAcc' -skip 'TestAccACLResource_WithRole|TestAccRoleResource' -timeout=120m
+        shell: bash
+        run: |
+          mkdir -p test-results
+          set -o pipefail
+          go test ./internal/provider/... -v -count=1 -run '^TestAcc' -skip 'TestAccACLResource_WithRole|TestAccRoleResource' -timeout=120m \
+            2>&1 | tee test-results/acceptance-tests.log
+
+      - name: Upload acceptance test output
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: acceptance-test-output
+          path: test-results/acceptance-tests.log
+          if-no-files-found: error
+          retention-days: 14

--- a/internal/provider/makefile_test.go
+++ b/internal/provider/makefile_test.go
@@ -60,7 +60,7 @@ func TestGitHubWorkflow_AcceptanceStepQuarantinesFlakyTests(t *testing.T) {
 	}
 
 	workflow := string(content)
-	acceptanceGoTestCommandRe := regexp.MustCompile(`(?s)run:\s*go\s+test\s+\./internal/provider/\.\.\.`)
+	acceptanceGoTestCommandRe := regexp.MustCompile(`(?s)-\s+name:\s+Run acceptance tests.*?go\s+test\s+\./internal/provider/\.\.\.`)
 	if !acceptanceGoTestCommandRe.MatchString(workflow) {
 		t.Fatalf("workflow must include acceptance go test command for internal/provider tests")
 	}
@@ -77,6 +77,15 @@ func TestGitHubWorkflow_AcceptanceStepQuarantinesFlakyTests(t *testing.T) {
 
 	if !strings.Contains(workflow, "TODO(#65)") {
 		t.Fatalf("workflow must document quarantine with TODO(#65)")
+	}
+
+	if !strings.Contains(workflow, "tee test-results/acceptance-tests.log") {
+		t.Fatalf("workflow must capture acceptance test output to a stable artifact path")
+	}
+
+	uploadArtifactRe := regexp.MustCompile(`(?s)-\s+name:\s+Upload acceptance test output.*?if:\s+failure\(\).*?uses:\s+actions/upload-artifact@v4.*?path:\s+test-results/acceptance-tests\.log`)
+	if !uploadArtifactRe.MatchString(workflow) {
+		t.Fatalf("workflow must upload acceptance test output artifact on failure")
 	}
 }
 


### PR DESCRIPTION
## Summary
- capture acceptance test output to `test-results/acceptance-tests.log`
- upload that log as a workflow artifact when the acceptance step fails
- extend the workflow guard test to assert the log capture and artifact upload remain in place

## Validation
- `make test`
- `go test ./internal/provider -run 'TestGNUmakefile_TestAccTargetRunsOnlyAcceptanceTests' -count=1 -v`
- `CI=1 go test ./internal/provider -run 'TestGitHubWorkflow_AcceptanceStepQuarantinesFlakyTests' -count=1 -v`
